### PR TITLE
Updating image name for ruby-2.0

### DIFF
--- a/layers/rhel-server-7-beta/ose3b1-base/@target/install
+++ b/layers/rhel-server-7-beta/ose3b1-base/@target/install
@@ -46,7 +46,7 @@ for image in \
 	registry.access.redhat.com/openshift3_beta/ose-pod \
 	registry.access.redhat.com/openshift3_beta/ose-sti-builder \
 	openshift/hello-openshift \
-	openshift/ruby-20-centos \
+	openshift/ruby-20-centos7 \
 	mysql; do
   docker pull $image
 done 


### PR DESCRIPTION
There is a new ruby-20 image(ruby-20-centos7) and we are going to get rid of the old one(ruby-20-centos)