### PR TITLE
Use subscription-manager to enable and disable repos

### DIFF
--- a/utils/vm-functions
+++ b/utils/vm-functions
@@ -19,8 +19,7 @@ register_channels() {
     else
       subscription-manager attach --auto
     fi
-
-    yum-config-manager --disable &>/dev/null
+    subscription-manager repos --disable=*
 
   else
     if [ -x /usr/bin/dnf ]; then
@@ -38,7 +37,7 @@ register_channels() {
 
   for CHANNEL in "$@"; do
     if [ -n "$RHN_USER" -a -x /sbin/subscription-manager ]; then
-      yum-config-manager --enable $CHANNEL &>/dev/null
+      subscription-manager repos --enable=$CHANNEL    
     else
       curl -so /etc/yum.repos.d/auto-$CHANNEL.repo $MIRROR_RHN/$CHANNEL.repo
     fi


### PR DESCRIPTION
A few of the subscription pools cause issues with duff repos. It seems that yum-config-manager is not disabling all the repos so if any of them are duff then they cause a build of a layer to fail.

This swaps yum-config-manager to subscription-manager repos