### PR TITLE
Fix rhel-server-6 and centos-7 errors

### DIFF
--- a/targets/openstack/@target/install
+++ b/targets/openstack/@target/install
@@ -2,9 +2,9 @@
 
 . vm-functions
 
-if grep -q 'release 6' /etc/redhat-release; then
+if grep -q 'Red Hat Enterprise Linux Server release 6' /etc/redhat-release; then
   register_channels rhel-6-server-rh-common-rpms rhel-6-server-rpms
-elif grep -q 'release 7' /etc/redhat-release; then
+elif grep -q 'Red Hat Enterprise Linux Server release 7' /etc/redhat-release; then
   register_channels rhel-7-server-rh-common-rpms rhel-7-server-rpms
 else
   register_channels

--- a/targets/vagrant-libvirt/@target/install
+++ b/targets/vagrant-libvirt/@target/install
@@ -2,9 +2,9 @@
 
 . vm-functions
 
-if grep -q 'release 6' /etc/redhat-release; then
+if grep -q 'Red Hat Enterprise Linux Server release 6' /etc/redhat-release; then
   register_channels rhel-6-server-rpms
-elif grep -q 'release 7' /etc/redhat-release; then
+elif grep -q 'Red Hat Enterprise Linux Server release 7' /etc/redhat-release; then
   register_channels rhel-7-server-rpms
 else
   register_channels

--- a/targets/vagrant-virtualbox/@target/install
+++ b/targets/vagrant-virtualbox/@target/install
@@ -2,9 +2,9 @@
 
 . vm-functions
 
-if grep -q 'release 6' /etc/redhat-release; then
+if grep -q 'Red Hat Enterprise Linux Server release 6' /etc/redhat-release; then
   register_channels rhel-6-server-rpms
-elif grep -q 'release 7' /etc/redhat-release; then
+elif grep -q 'Red Hat Enterprise Linux Server release 7' /etc/redhat-release; then
   register_channels rhel-7-server-rpms
 else
   register_channels

--- a/utils/install_wrapper
+++ b/utils/install_wrapper
@@ -10,7 +10,7 @@ if ! [ -e /usr/local/bin/demobuilder-cleanup.sh ]; then
 fi
 
 if ! ./install; then
-  if [ -n "$RHN_USER" -a -x /sbin/subscription-manager -a -e /etc/pki/consumer/cert.pem ]; then
+  if [ -n "$RHN_USER" -a -x /usr/sbin/subscription-manager -a -e /etc/pki/consumer/cert.pem ]; then
     subscription-manager unregister
   fi
 

--- a/utils/vm-functions
+++ b/utils/vm-functions
@@ -5,8 +5,8 @@ interface_ip() {
 }
 
 register_channels() {
-  if [ -n "$RHN_USER" -a -x /sbin/subscription-manager -a ! -e /etc/pki/consumer/cert.pem ]; then
-    cp /etc/os-release /etc/os-release-
+  if [ -n "$RHN_USER" -a -x /usr/sbin/subscription-manager -a ! -e /etc/pki/consumer/cert.pem ]; then
+    [ -e /etc/os-release ] && cp /etc/os-release /etc/os-release-
 
     unsetx
     subscription-manager register --username "$RHN_USER" --password "$RHN_PASS"
@@ -36,7 +36,7 @@ register_channels() {
   fi
 
   for CHANNEL in "$@"; do
-    if [ -n "$RHN_USER" -a -x /sbin/subscription-manager ]; then
+    if [ -n "$RHN_USER" -a -x /usr/sbin/subscription-manager ]; then
       subscription-manager repos --enable=$CHANNEL
     else
       curl -so /etc/yum.repos.d/auto-$CHANNEL.repo $MIRROR_RHN/$CHANNEL.repo
@@ -101,10 +101,10 @@ cleanup() {
     sed -i -e '/^proxy=/ d;' /etc/yum.conf
   fi
 
-  if [ -n "$RHN_USER" -a -x /sbin/subscription-manager -a -e /etc/pki/consumer/cert.pem ]; then
+  if [ -n "$RHN_USER" -a -x /usr/sbin/subscription-manager -a -e /etc/pki/consumer/cert.pem ]; then
     subscription-manager unregister || true
     rm /var/lib/rhsm/branded_name
-    mv /etc/os-release- /etc/os-release
+    [ -e /etc/os-release- ] && mv /etc/os-release- /etc/os-release
   fi
 
   if [ -e /etc/fedora-release ]; then


### PR DESCRIPTION
Pull request to fix three minor bugs:
* subscription-manager is not available at /sbin/subscription-manager in rhel6
* ignore missing /etc/os-release (rhel 6 and centos 6)
* centos /etc/redhat-release matches on 'release X' causing an attempt to register rhel channels